### PR TITLE
tcp: Clear buffer on new connection

### DIFF
--- a/src/bin/tcp.rs
+++ b/src/bin/tcp.rs
@@ -103,16 +103,16 @@ async fn main(spawner: Spawner) {
 
     loop {
         let mut socket = TcpSocket::new(stack, &mut rx_buffer, &mut tx_buffer);
-        socket.set_timeout(Some(Duration::from_secs(10)));
-        socket.set_keep_alive(Some(Duration::from_secs(10)));
+        socket.set_timeout(Some(Duration::from_secs(1)));
 
         log::info!("Listening on TCP:1234...");
         if let Err(e) = socket.accept(1234).await {
             log::warn!("accept error: {:?}", e);
             continue;
         }
-
         log::info!("Received connection from {:?}", socket.remote_endpoint());
+
+        cons.clear();
 
         loop {
             match socket


### PR DESCRIPTION
While TCP ensures that individual packets arrive whole and in order, there is no guarantee that a frame arrives in a single packet, which means some of it could be lost.

Instead of retransmitting the rest of the frame (as in that time the animation pattern will change anyway, so it's better to just send a new frame), we will abandon the stream on any connection issues and restart transmitting with the next entire frame.

In order for that to work, receiver needs to drop any partial frames it received in the meantime, so that the beginning of the next frame is not interpreted as the end of the previous one, and some arbitrary bytes in the middle of it aren't treated as the length of the next one.

Additionally, the connection is abandoned much faster in case no data is received, to allow for a faster reconnection. For that reason the timeout was lowered to 1 second, and keepalive packets were turned off entirely.